### PR TITLE
We need now 2 ndk mediacodec flavors

### DIFF
--- a/src/com/archos/medialib/LibAvos.java
+++ b/src/com/archos/medialib/LibAvos.java
@@ -201,7 +201,13 @@ public class LibAvos {
         loadLibrary(ctx, "deinterlace", armHasNeon, false);
         loadLibrary(ctx, "audiocompress", armHasNeon, false);
 
-        String api = "21";
+        String api;
+        if (Build.VERSION.SDK_INT < 26)
+            api = "21";
+        else
+            api = "26";
+
+	if (DBG) Log.d(TAG, "Min api level for mediacodec: " + api);
 
         loadLibrary(ctx, "sfdec", armHasNeon, false);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || (Build.VERSION.SDK_INT == Build.VERSION_CODES.M && Build.VERSION.PREVIEW_SDK_INT == 0))  {
@@ -217,7 +223,7 @@ public class LibAvos {
         loadLibrary(ctx, "avos", armHasNeon, false);
         if (loadLibrary(ctx, "avosjni", armHasNeon, false)) {
             nativeInit(ctx.getPackageName(), sIsPluginAvailable);
-            nativeLoadLibraryRTLDGlobal("libsfdec.core.21.so");
+            nativeLoadLibraryRTLDGlobal("libsfdec.core." + api + ".so");
             sIsAvailable = true;
         } else {
             sIsAvailable = false;


### PR DESCRIPTION
Due to the usage of AMediaCodec_setParameters which is min api 26, we need now 2 flavors for sfdec.core  (21 and 26) implemented via sfdec_ndkmediacodec.cpp
Load the matching library accordingly