### PR TITLE
Fix episode regex to consider episode number > 999

### DIFF
--- a/src/com/archos/mediascraper/ShowUtils.java
+++ b/src/com/archos/mediascraper/ShowUtils.java
@@ -70,11 +70,11 @@ public final class ShowUtils {
     // Name patterns where the show is present first. Examples below.
     private static final Pattern[] patternsShowFirst = {
             // almost anything that has S 00 E 00 in it and recognize shows with year as season number
-            Pattern.compile("(.+?)" + SEP_MANDATORY + "(?:s|seas|season)" + SEP_OPTIONAL + "(20\\d{2}|\\d{1,2})" + SEP_OPTIONAL + "(?:e|ep|episode)" + SEP_OPTIONAL + "(\\d{1,3})(?!\\d).*", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("(.+?)" + SEP_MANDATORY + "(?:s|seas|season)" + SEP_OPTIONAL + "(20\\d{2}|\\d{1,2})" + SEP_OPTIONAL + "(?:e|ep|episode)" + SEP_OPTIONAL + "(\\d{1,4})(?!\\d).*", Pattern.CASE_INSENSITIVE),
             // almost anything that has 00 x 00, note mandatory separator to fixe detection of movies 5.1x264 as Season 1 episode 264
-            Pattern.compile("(.+?)" + SEP_MANDATORY + "(20\\d{2}|\\d{1,2})" + SEP_OPTIONAL + "x" + SEP_MANDATORY + "(\\d{1,3})(?!\\d).*", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("(.+?)" + SEP_MANDATORY + "(20\\d{2}|\\d{1,2})" + SEP_OPTIONAL + "x" + SEP_MANDATORY + "(\\d{1,4})(?!\\d).*", Pattern.CASE_INSENSITIVE),
             // special case to avoid x264 or x265
-            Pattern.compile("(.+?)" + SEP_MANDATORY + "(20\\d{2}|\\d{1,2})" + SEP_OPTIONAL + "x" + SEP_OPTIONAL + "(?!(?:264|265|720))(\\d{1,3})(?!\\d).*", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("(.+?)" + SEP_MANDATORY + "(20\\d{2}|\\d{1,2})" + SEP_OPTIONAL + "x" + SEP_OPTIONAL + "(?!(?:264|265|720))(\\d{1,4})(?!\\d).*", Pattern.CASE_INSENSITIVE),
             // Disable following pattern since it makes L.627 or OSS 117 movies identified as TV serie
             // foo.103 and similar
             // Note: can detect movies that contain 3 digit numbers like "127 hours" or shows that have such numbers in their name like "zoey 101"
@@ -84,9 +84,9 @@ public final class ShowUtils {
     // Name patterns which begin with the number of the episode
     private static final Pattern[] patternsEpisodeFirst = {
             // anything that starts with S 00 E 00, text after "-" getting ignored
-            Pattern.compile(SEP_OPTIONAL + "(?:s|seas|season)" + SEP_OPTIONAL + "(\\d{1,2})" + SEP_OPTIONAL + "(?:e|ep|episode)" + SEP_OPTIONAL + "(\\d{1,3})(?!\\d)" + SEP_OPTIONAL + "([^-]*+).*", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(SEP_OPTIONAL + "(?:s|seas|season)" + SEP_OPTIONAL + "(\\d{1,2})" + SEP_OPTIONAL + "(?:e|ep|episode)" + SEP_OPTIONAL + "(\\d{1,4})(?!\\d)" + SEP_OPTIONAL + "([^-]*+).*", Pattern.CASE_INSENSITIVE),
             // anything that starts with 00 x 00, text after "-" getting ignored like in "S01E15 - ShowName - Ignored - still ignored"
-            Pattern.compile(SEP_OPTIONAL + "(\\d{1,2})" + SEP_OPTIONAL + "x" + SEP_OPTIONAL + "(\\d{1,3})(?!\\d)" + SEP_OPTIONAL + "([^-]*+).*", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(SEP_OPTIONAL + "(\\d{1,2})" + SEP_OPTIONAL + "x" + SEP_OPTIONAL + "(\\d{1,4})(?!\\d)" + SEP_OPTIONAL + "([^-]*+).*", Pattern.CASE_INSENSITIVE),
         };
 
     public static String cleanUpName(String name) {

--- a/src/com/archos/mediascraper/preprocess/TvShowPathMatcher.java
+++ b/src/com/archos/mediascraper/preprocess/TvShowPathMatcher.java
@@ -71,7 +71,7 @@ class TvShowPathMatcher implements InputMatcher {
     private static final String SEASON = "(?:S|SEAS|SEASON)";
     private static final String EPISODE = "(?:E|EP|EPISODE)";
     private static final String SEASON_NUMBER = "20\\d{2}|\\d{1,2}";
-    private static final String EPISODE_NUMBER = "\\d{1,3}";
+    private static final String EPISODE_NUMBER = "\\d{1,4}";
     private static final String NOT_DECIMAL = "(?!\\d).*";
     private static final String LETTER_NUMBER_SEP = "(?:[\\p{L}\\p{N}]++[\\s._-]*+)"; // contains no date between ()...
 


### PR DESCRIPTION
Wano Country Arc of One Piece has Episode number > 999 
https://www.themoviedb.org/tv/37854/season/21

Since the pattern is specified to look for only 3 digits in episode number, it fails to fetch info from tmdb after S21E999

Have replaced \d{1,3} to \d{1,4} everywhere to solve this issue

