### PR TITLE
feat: Add .sup (PGS) subtitle file type support

### DIFF
--- a/src/com/archos/mediaprovider/ArchosMediaFile.java
+++ b/src/com/archos/mediaprovider/ArchosMediaFile.java
@@ -132,10 +132,11 @@ public class ArchosMediaFile {
     public static final int FILE_TYPE_SRR           = 1207;
     public static final int FILE_TYPE_MPL           = 1208;
     public static final int FILE_TYPE_TXT           = 1209;
+    public static final int FILE_TYPE_SUP           = 1210;
 
     // keep in sync with com.archos.mediacenter.video.utils.VideoUtils.SUBTITLES_ARRAY
     private static final int FIRST_SUBTITLE_FILE_TYPE = FILE_TYPE_SRT;
-    private static final int LAST_SUBTITLE_FILE_TYPE = FILE_TYPE_TXT;
+    private static final int LAST_SUBTITLE_FILE_TYPE = FILE_TYPE_SUP;
 
     private static final int FILE_TYPE_ANY_VIDEO = 1300;
 
@@ -279,6 +280,7 @@ public class ArchosMediaFile {
         addFileType("MPL", FILE_TYPE_MPL, "text/plain");
         addFileType("SRR", FILE_TYPE_SRR, "text/plain");
         addFileType("TXT", FILE_TYPE_TXT, "text/plain");
+        addFileType("SUP", FILE_TYPE_SUP, "application/pgs");
 
         addFileType("WTV", FILE_TYPE_WTV, "video/wtv");
 


### PR DESCRIPTION
- Defined a new FILE_TYPE_SUP constant for PGS subtitle files.
- Updated LAST_SUBTITLE_FILE_TYPE bounds to include the new .sup file type.
- Registered the "SUP" extension and mapped it to the "application/pgs" MIME type.

This ensures the media scanner correctly identifies .sup files as valid subtitle files.

Prerequisites: https://github.com/nova-video-player/aos-avos/pull/6